### PR TITLE
fix: remove underscore from assets dir

### DIFF
--- a/packages/reveal-compiler-explorer-demo/reveal-md.json
+++ b/packages/reveal-compiler-explorer-demo/reveal-md.json
@@ -11,5 +11,6 @@
     ],
     "staticDirs": [
         "images"
-    ]
+    ],
+    "assetsDir": "assets"
 }


### PR DESCRIPTION
GH pages don't like underscores

BREAKING FORCE VERSION BUMP